### PR TITLE
Fix Timer GetTimer return flag

### DIFF
--- a/practicas/src/1-modulos/03-timer/Timer.cpp
+++ b/practicas/src/1-modulos/03-timer/Timer.cpp
@@ -99,14 +99,17 @@ bool Timer::SetTimer( uint32_t time )
 
 bool Timer::GetTimer( uint32_t &time )
 {
-	bool salida = false;
+       bool salida = false;
 
-	if ( m_tmrHandler )
-	{
-		if ( m_tmrRun )
-			time = TicksToBase( m_tmrRun );
-	}
-	return salida;
+       if ( m_tmrHandler )
+       {
+               if ( m_tmrRun )
+               {
+                       time = TicksToBase( m_tmrRun );
+                       salida = true;
+               }
+       }
+       return salida;
 }
 
 void Timer::StandByTimer( const standby_t accion )


### PR DESCRIPTION
## Summary
- Ensure Timer::GetTimer returns true when a running timer value is read

## Testing
- `g++ -std=c++17 -Ipracticas/src/1-modulos/03-timer -Ipracticas/src -c practicas/src/1-modulos/03-timer/Timer.cpp`

------
https://chatgpt.com/codex/tasks/task_e_68951775ac98832ea7e96ea9a0147f7d