### PR TITLE
Add micro and milli second timer bases

### DIFF
--- a/practicas/src/1-modulos/03-timer/Timer.cpp
+++ b/practicas/src/1-modulos/03-timer/Timer.cpp
@@ -13,8 +13,8 @@ Timer::Timer()
 	m_tmrEvent = false;
 	m_tmrStandBy = false;
 
-	m_tmrHandler = nullptr ;
-	m_tmrBase = DEC;
+       m_tmrHandler = nullptr ;
+       m_tmrBase = MILISEG;
 	InstalarPerifericoTemporizado(this);
 
 }
@@ -25,8 +25,8 @@ Timer::Timer( const bases_t base , const Timer_Callback callback )
 	m_tmrEvent = false;
 	m_tmrStandBy = false;
 
-	m_tmrHandler = callback ;
-	m_tmrBase = base;
+       m_tmrHandler = callback ;
+       m_tmrBase = base;
 	InstalarPerifericoTemporizado(this);
 
 }
@@ -171,34 +171,38 @@ Timer::~Timer()
 }
 uint32_t Timer::BaseToticks( uint32_t time )
 {
-	switch ( m_tmrBase )
-	{
-		case DEC:
-			time *= DECIMAS;
-			break;
-		case SEG:
-			time *= DECIMAS * SEGUNDOS;
-			break;
-		case MIN:
-			time *= DECIMAS * SEGUNDOS * MINUTOS ;
-			break;
-	}
-	return time;
+       switch ( m_tmrBase )
+       {
+               case MICROSEG:
+                       break;
+               case MILISEG:
+                       time *= MILISEGUNDOS;
+                       break;
+               case SEG:
+                       time *= MILISEGUNDOS * SEGUNDOS;
+                       break;
+               case MIN:
+                       time *= MILISEGUNDOS * SEGUNDOS * MINUTOS ;
+                       break;
+       }
+       return time;
 }
 
 uint32_t Timer::TicksToBase( uint32_t time ) const
 {
-	switch ( m_tmrBase )
-	{
-		case DEC:
-			time /= DECIMAS;
-			break;
-		case SEG:
-			time /= ( SEGUNDOS * DECIMAS );
-			break;
-		case MIN:
-			time /= ( MINUTOS * SEGUNDOS * DECIMAS );
-			break;
-	}
-	return time;
+       switch ( m_tmrBase )
+       {
+               case MICROSEG:
+                       break;
+               case MILISEG:
+                       time /= MILISEGUNDOS;
+                       break;
+               case SEG:
+                       time /= ( SEGUNDOS * MILISEGUNDOS );
+                       break;
+               case MIN:
+                       time /= ( MINUTOS * SEGUNDOS * MILISEGUNDOS );
+                       break;
+       }
+       return time;
 }

--- a/practicas/src/1-modulos/03-timer/Timer.h
+++ b/practicas/src/1-modulos/03-timer/Timer.h
@@ -23,8 +23,8 @@ class Timer : public PerifericoTemporizado
 		volatile uint8_t  	m_tmrBase ;
 
 	public:
-		enum 	bases_t 	{ DEC , SEG , MIN };
-		enum 	ticks_t 	{ DECIMAS = 100 , SEGUNDOS = 10 , MINUTOS  = 60 };
+		enum    bases_t         { MICROSEG , MILISEG , SEG , MIN };
+		enum    ticks_t         { MILISEGUNDOS = 1000 , SEGUNDOS = 1000 , MINUTOS  = 60 };
 		enum 	standby_t 	{ RUN , PAUSE };
 
 		static uint8_t	m_countTimer ;

--- a/practicas/src/2-aplicacion/ejercicio16/main_ej16.cpp
+++ b/practicas/src/2-aplicacion/ejercicio16/main_ej16.cpp
@@ -46,8 +46,8 @@ Gpio Sirena(Gpio::PORT0, 3, Gpio::PUSHPULL, Gpio::HIGH, Gpio::OUTPUT);
 void handlers(void);
 
 int main(void) {
-	SysTick_InstalarCallBack(handlers);
-	SysTick_Inicializar(1);
+       SysTick_InstalarCallBack(handlers);
+       SysTick_Inicializar(1, SYSTICK_MS);
 	Potencia potencia = MAXIMA;
 	uint8_t tecla = NO_KEY;
 	volatile uint32_t tiempo = 0;

--- a/practicas/src/2-aplicacion/main_ej3.cpp
+++ b/practicas/src/2-aplicacion/main_ej3.cpp
@@ -27,8 +27,8 @@ void titilar(void);
 void AtenderPerifericosTemporizados(void);
 
 int main(void) {
-	SysTick_InstalarCallBack(AtenderPerifericosTemporizados);
-	SysTick_Inicializar(1);
+       SysTick_InstalarCallBack(AtenderPerifericosTemporizados);
+       SysTick_Inicializar(1, SYSTICK_MS);
 	Led.clr();
 	bool flag = true;
 	while (1) {

--- a/practicas/src/3-firmware/systick/systick.cpp
+++ b/practicas/src/3-firmware/systick/systick.cpp
@@ -50,21 +50,28 @@ void SysTick_InstalarCallBack( void (*callBack)(void) )
 	 sysTickCallback = (volatile void (*)(void))callBack;
 }
 
-uint32_t SysTick_Inicializar( uint32_t ms )
+uint32_t SysTick_Inicializar( uint32_t tiempo , const systick_t base )
 {
-	uint32_t frecuenciaSystick , ticks ;
-	frecuenciaSystick = 1000 / ms;				 	// frecuenciaSystick = 1 / ( ms * 0.001)
+        uint32_t ticks ;
 
-	ticks = FREQ_CLOCK / frecuenciaSystick;  		// ticks = Tsystic / Tclock ;
+        switch ( base )
+        {
+                case SYSTICK_US:
+                        ticks = ( FREQ_CLOCK / 1000000 ) * tiempo;
+                        break;
+                case SYSTICK_MS:
+                        ticks = ( FREQ_CLOCK / 1000 ) * tiempo;
+                        break;
+        }
 
-	if (ticks > MAX_TICKS)
-		return 1 ;          						// Reload value fuera de rango
+        if (ticks > MAX_TICKS)
+                return 1 ;                                                      // Reload value fuera de rango
 
-	SysTick->RELOAD = ticks - 1;  					// Cargamos la Cuenta
+        SysTick->RELOAD = ticks - 1;                                    // Cargamos la Cuenta
 
-	SysTick->CURR = 0;   							// SysTick Counter en 0 para que se recargue
+        SysTick->CURR = 0;                                                      // SysTick Counter en 0 para que se recargue
 
-	SysTick->CTRL = 7;								// ENABLE = 1, TICKINT = 1, CLKSOURCE = 1;
+        SysTick->CTRL = 7;                                                              // ENABLE = 1, TICKINT = 1, CLKSOURCE = 1;
 
-	return 0;
+        return 0;
 }

--- a/practicas/src/3-firmware/systick/systick.h
+++ b/practicas/src/3-firmware/systick/systick.h
@@ -22,7 +22,8 @@ using namespace std;
  *** PROTOTIPOS GLOBALES
  **********************************************************************************************************************************/
 void SysTick_InstalarCallBack( void (*callBack)(void) );
-uint32_t SysTick_Inicializar( uint32_t ms );
+enum systick_t { SYSTICK_US , SYSTICK_MS };
+uint32_t SysTick_Inicializar( uint32_t tiempo , const systick_t base );
 
 /***********************************************************************************************************************************
  *** COMPATIBILIDAD CON C PARA SysTick_Handler PROPIA


### PR DESCRIPTION
## Summary
- Allow creating `Timer` objects in microsecond or millisecond units
- Expand `SysTick` to initialize with microsecond or millisecond periods
- Update example applications to use the new SysTick API

## Testing
- `g++ -c practicas/src/1-modulos/03-timer/Timer.cpp -Ipracticas/src/1-modulos/06-PerifericosTemporizados -Ipracticas/src -Ipracticas/src/3-firmware/systick -std=c++17`
- `g++ -c practicas/src/3-firmware/systick/systick.cpp -Ipracticas/src -std=c++17`
- ❌ `g++ -c practicas/src/2-aplicacion/main_ej3.cpp -Ipracticas/src -Ipracticas/src/1-modulos/03-timer -Ipracticas/src/3-firmware/systick -Ipracticas/src/1-modulos/04-EntradasDigitales -Ipracticas/src/1-modulos/05-SalidasDigitales -Ipracticas/src/1-modulos/06-PerifericosTemporizados -Ipracticas/src/1-modulos/02-gpio -std=c++17` (missing Inputs.h)


------
https://chatgpt.com/codex/tasks/task_e_68a10d76d904832eaebb6467f0b19db4